### PR TITLE
secu: check user if still exist, before returning the session

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -51,18 +51,18 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   callbacks: {
-      async jwt({ token, user, account }) {
-        if (account) {
-          token.id = user.id;
-        }
-        if (user) {
-          return {
-            ...token,
-            username: user.username,
-          };
-        }
-        return token;
-      },
+    async jwt({ token, user, account }) {
+      if (account) {
+        token.id = user.id;
+      }
+      if (user) {
+        return {
+          ...token,
+          username: user.username,
+        };
+      }
+      return token;
+    },
     async session({ session, token }) {
       const existingUser = await prisma.user.findUnique({
         where: { username: token?.username as string},


### PR DESCRIPTION
Instead of returning the null, I've opted to use the 'signOut' function from nextauth. This choice not only signs the user out but also ensures the removal of the stored session cookie in the current browsing session, providing a seamless logout experience.